### PR TITLE
Add identifier attribute for source tables

### DIFF
--- a/models/sources.yml
+++ b/models/sources.yml
@@ -6,4 +6,6 @@ sources:
     schema:  "{{ var('input_schema') }}"
     tables:
       - name: medical_claim
+        identifier: tuva_input_claims
       - name: eligibility
+        identifier: tuva_input_eligibility


### PR DESCRIPTION
## Describe your changes
This PR adds the identifier property to the source.yml file for each source table. This change is necessary as the input table names (tuva_input_eligibility and tuva_input_claims) differ from the Tuva Claims data model.

## Validation & Testing
Tested locally with the following dbt command.

```
dbt build --vars '{ input_database: transformed_data, input_schema: prod_base, output_database: transformed_data, output_schema: prod_tuva }'
```